### PR TITLE
Fix: Remove lg: prefix from gap-x-lg class in AppTopBar for consistent spacing

### DIFF
--- a/src/molecules/AppTopBar.tsx
+++ b/src/molecules/AppTopBar.tsx
@@ -91,7 +91,7 @@ function AppTopbar(props: TAppTopBarProps): React.JSX.Element {
                 </div>
               </button>
             )}
-            <div className='flex items-center lg:gap-x-lg'>
+            <div className='flex items-center gap-x-lg'>
               {
                 !backBtn && <button className="ri-menu-2-fill text-light-type-gray type-2xl-title dark:text-dark-type-gray lg:hidden" onClick={onClickMenu}>
                   <span className="sr-only">Menu</span>


### PR DESCRIPTION
## Description
This PR fixes the spacing consistency in the AppTopBar component by removing the  responsive prefix from the  class.

## Changes Made
- Simplified  class by removing  responsive prefix
- This ensures consistent spacing across all screen sizes instead of only applying on large screens

## Files Modified
- 

## Testing
Please test the TopBar component across different screen sizes to ensure consistent spacing behavior.