### PR TITLE
fix: remove 'hidden' class from onboarding link

### DIFF
--- a/src/molecules/AppTopBar.tsx
+++ b/src/molecules/AppTopBar.tsx
@@ -77,7 +77,7 @@ function AppTopbar(props: TAppTopBarProps): React.JSX.Element {
         <div className="flex flex-row items-center justify-between px-3xl">
           {logo ? logo : <img src={optimusLogo} />}
 
-          <div className="hidden cursor-pointer py-lg capitalize text-light-type-accent transition-all duration-300 type-base-head hover:text-light-type-accent-bold md:flex dark:text-dark-type-accent dark:hover:text-dark-type-accent-bold">
+          <div className="cursor-pointer py-lg capitalize text-light-type-accent transition-all duration-300 type-base-head hover:text-light-type-accent-bold dark:text-dark-type-accent dark:hover:text-dark-type-accent-bold">
             {onboardLink ?? 'Open account'}
           </div>
         </div>


### PR DESCRIPTION
remove 'hidden' class from onboarding link as it was blocking the text "logout" from showing in mobile